### PR TITLE
Add Trickster Takeover pack metadata

### DIFF
--- a/packs.json
+++ b/packs.json
@@ -538,14 +538,24 @@
 		"position": 53,
 		"size": 60
 	},
-	{
-		"cgdb_id": 54,
-		"code": "winter",
-		"date_release": "2025-06-20",
-		"name": "Winter Soldier",
-		"octgn_id": "8e74fa84-01d6-42e0-8b7d-b02638e96f5c",
-		"pack_type_code": "hero",
-		"position": 54,
-		"size": 60
-	}
+        {
+                "cgdb_id": 54,
+                "code": "winter",
+                "date_release": "2025-06-20",
+                "name": "Winter Soldier",
+                "octgn_id": "8e74fa84-01d6-42e0-8b7d-b02638e96f5c",
+                "pack_type_code": "hero",
+                "position": 54,
+                "size": 60
+        },
+        {
+                "cgdb_id": 55,
+                "code": "trickster_takeover",
+                "date_release": "2025-08-22",
+                "name": "Trickster Takeover",
+                "octgn_id": "01241dea-434c-4d22-b870-a5d73c96148e",
+                "pack_type_code": "scenario",
+                "position": 55,
+                "size": 66
+        }
 ]

--- a/sets.json
+++ b/sets.json
@@ -1589,14 +1589,29 @@
 		"name": "Winter Soldier",
 		"card_set_type_code": "hero"
 	},
-	{
-		"code": "winter_soldier_nemesis",
-		"name": "Winter Soldier Nemesis",
-		"card_set_type_code": "nemesis"
-	},
-	{
-		"code": "whiteout",
-		"name": "Whiteout",
-		"card_set_type_code": "modular"
-	}
+        {
+                "code": "winter_soldier_nemesis",
+                "name": "Winter Soldier Nemesis",
+                "card_set_type_code": "nemesis"
+        },
+        {
+                "code": "whiteout",
+                "name": "Whiteout",
+                "card_set_type_code": "modular"
+        },
+        {
+                "code": "enchantress_villain",
+                "name": "Enchantress",
+                "card_set_type_code": "villain"
+        },
+        {
+                "code": "god_of_lies",
+                "name": "God of Lies",
+                "card_set_type_code": "villain"
+        },
+        {
+                "code": "trickster_magic",
+                "name": "Trickster Magic",
+                "card_set_type_code": "modular"
+        }
 ]


### PR DESCRIPTION
## Summary
- add Trickster Takeover to pack list
- register Enchantress, God of Lies, and Trickster Magic sets
- set Trickster Takeover release date to 2025-08-22

## Testing
- `./validate.py -v 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68aa5b2defb08327820257a6166fa1a7